### PR TITLE
ci: tag images with bare commit SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
         uses: docker/metadata-action@v5.5.1
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=sha,prefix=,format=short
       # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
       # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
       # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,8 +41,8 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            # minimal
             type=pep440,pattern={{version}}
+            type=sha,prefix=,format=short
       # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
       # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
       # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.


### PR DESCRIPTION
## Summary
- Tercen's `_resolveContainerTag` appends the install version to the operator.json container reference. When the install version is a git tag (e.g. `1.0.12`), Tercen resolves it to a commit SHA and pulls `ghcr.io/tercen/plot_operator:<short-sha>`.
- Without a matching ghcr tag the worker fails with `manifest unknown` (hit on Sartorius today after publishing 1.0.12 — recovered by retagging `:1.0.12` → `:3c7973d` manually).
- Release workflow: add `type=sha,prefix=,format=short` alongside the existing pep440 tag so every tagged release also publishes `:<7-char-sha>`.
- CI workflow: replace the default metadata tag set (which emits `sha-<sha>` with a `sha-` prefix Tercen doesn't expect) with explicit branch + bare short SHA tags so master pushes are installable by either reference.

## Test plan
- [ ] Tag a new release (or push to master) and confirm both `:<version>` / `:<branch>` and `:<short-sha>` tags appear on ghcr
- [ ] Library install of the new version on Sartorius pulls successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)