### PR TITLE
Multi-stage Dockerfile, no renv at runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,15 @@
-FROM tercen/runtime-r44-minimal-plot:4.4.3-1 AS builder
+FROM tercen/runtime-r44-minimal-plot:4.4.3-2 AS builder
 
 # Operator-specific CRAN packages installed on top of the
 # tercen/teRcenHttp/mtercen/teRcenApi/teRcen + Cairo stack baked
 # into the base image.
-RUN installr -d ggplot2 dplyr svglite jsonlite scales tidyr zip
+#
+# ragg provides PNG/JPEG raster devices without X11 (the alpine
+# base has no X11). With ragg installed, ggplot2::ggsave(device="png")
+# auto-picks ragg::agg_png. libtiff comes from the base image.
+RUN installr -d ggplot2 ragg dplyr svglite jsonlite scales tidyr zip
 
-FROM tercen/runtime-r44-minimal-plot:4.4.3-1
+FROM tercen/runtime-r44-minimal-plot:4.4.3-2
 
 COPY --from=builder /usr/local/lib/R/library /usr/local/lib/R/library
 COPY main.R utils.R utils_colors.R palettes.json /operator/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,17 @@
-FROM tercen/runtime-r44:4.4.3-7
+FROM tercen/runtime-r44-minimal-plot:4.4.3-1 AS builder
 
-COPY . /operator
+# Operator-specific CRAN packages installed on top of the
+# tercen/teRcenHttp/mtercen/teRcenApi/teRcen + Cairo stack baked
+# into the base image.
+RUN installr -d ggplot2 dplyr svglite jsonlite scales tidyr zip
+
+FROM tercen/runtime-r44-minimal-plot:4.4.3-1
+
+COPY --from=builder /usr/local/lib/R/library /usr/local/lib/R/library
+COPY main.R utils.R utils_colors.R palettes.json /operator/
 WORKDIR /operator
 
-RUN R -e "renv::consent(provided = TRUE); renv::restore(confirm = FALSE)"
-
-ENV TERCEN_SERVICE_URI https://tercen.com
+ENV TERCEN_SERVICE_URI=https://tercen.com
 ENV OPENBLAS_NUM_THREADS=1
 
 ENTRYPOINT ["R", "--no-save", "--no-restore", "--no-environ", "--slave", "-f", "main.R", "--args"]


### PR DESCRIPTION
## Summary
- Switch base image to \`tercen/runtime-r44-minimal-plot:4.4.3-1\` (alpine + r-minimal, jemalloc preloaded, tercen/teRcen + Cairo baked in).
- Two-stage build: \`installr\` brings in \`ggplot2/dplyr/svglite/jsonlite/scales/tidyr/zip\` in the builder; the runtime stage just copies \`/usr/local/lib/R/library\`.
- Drops renv at runtime — packages live in the standard \`/usr/local/lib/R/library\` and load via default \`.libPaths()\`. This fixes "missing entries in the cache" / broken-symlink errors that hit when the runtime user couldn't reach the build user's renv cache.
- Image size **3.5 GB → 293 MB**.
- Files in the runtime stage are explicit \`COPY main.R utils.R utils_colors.R palettes.json\` — no \`.git\`, no \`renv/\`, no \`operator.json\` (operator.json is read by Tercen during install from the git checkout, not from the image).

## Test plan
- [x] Local docker build succeeds
- [x] Smoke test loads tercen, tercenApi, dplyr, ggplot2, svglite, jsonlite, scales, tidyr, zip
- [x] \`LD_PRELOAD=/usr/lib/libjemalloc.so.2\` set
- [ ] After release, install on Sartorius and re-run failed step

🤖 Generated with [Claude Code](https://claude.com/claude-code)