### PR TITLE
Dockerfile: include operator.json at runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN installr -d ggplot2 ragg dplyr svglite jsonlite scales tidyr zip
 FROM tercen/runtime-r44-minimal-plot:4.4.3-2
 
 COPY --from=builder /usr/local/lib/R/library /usr/local/lib/R/library
-COPY main.R utils.R utils_colors.R palettes.json /operator/
+COPY main.R utils.R utils_colors.R palettes.json operator.json /operator/
 WORKDIR /operator
 
 ENV TERCEN_SERVICE_URI=https://tercen.com


### PR DESCRIPTION
## Summary
\`utils.R\` reads operator.json at runtime via \`jsonlite::read_json(\"operator.json\")\` (in \`get_settings\`) to look up property defaults. The multi-stage refactor in 1.0.13 dropped it from the runtime stage, breaking actual runs:

\`\`\`
Error in open.connection(con, "rb") : cannot open the connection
cannot open file 'operator.json': No such file or directory
\`\`\`

operator.json is also read by Tercen during install (from the git checkout, not from the image), but the operator's own R code needs it at run time too.

## Test plan
- [x] Local docker build succeeds with operator.json in /operator
- [x] \`jsonlite::read_json(\"operator.json\")\$properties\` returns 25 entries inside the image
- [ ] After 1.0.14 release, re-run failed step