### PR TITLE
ci: also tag images with the annotated tag SHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,18 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Resolve annotated tag SHA
+        id: tagsha
+        # Tercen's installer derives the container tag from the GitHub
+        # zipball directory name, which uses the *tag object* SHA for
+        # annotated tags (not the commit SHA). Without this, the image
+        # CI pushes (`:<commit-sha>`) and the image Tercen tries to pull
+        # (`:<tag-sha>`) don't match.
+        run: |
+          tag_sha=$(git rev-parse --short=7 "${GITHUB_REF#refs/tags/}")
+          echo "short=$tag_sha" >> "$GITHUB_OUTPUT"
       - name: Update container in operator JSON
         run: |
           jq --arg variable "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${GITHUB_REF##*/}" '.container = $variable' operator.json
@@ -43,6 +55,7 @@ jobs:
           tags: |
             type=pep440,pattern={{version}}
             type=sha,prefix=,format=short
+            type=raw,value=${{ steps.tagsha.outputs.short }}
       # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
       # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
       # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.


### PR DESCRIPTION
## Summary
Tercen's operator installer derives the container tag from the GitHub zipball directory name. For **annotated** tags, GitHub names the dir using the tag *object* SHA, not the commit SHA — so \`github.sha\` (= commit) and the SHA Tercen pulls don't match, producing \`manifest unknown\` on every install.

Concrete example from 1.0.14:
- annotated tag SHA: \`df85eb4\` ← what Tercen pulls
- commit SHA: \`4de6df1\` ← what CI tagged

Fix: resolve the annotated tag SHA via \`git rev-parse --short=7 <tag>\` and add it to the metadata-action tag set as \`type=raw\`. Both \`:<commit-sha>\` (existing) and \`:<tag-sha>\` (new) are now published, so the install succeeds for both annotated and lightweight tags. \`fetch-depth: 0\` is needed so the tag object is available locally.

## Test plan
- [x] Local \`git rev-parse --short=7 1.0.14\` → \`df85eb4\` matches what Tercen tried to pull
- [ ] After release of next version, both tags appear on ghcr and library install needs no manual retag