### PR TITLE
ggsave: limitsize=FALSE for many-cell crosstabs

### DIFF
--- a/utils.R
+++ b/utils.R
@@ -621,7 +621,12 @@ generate_plot <-
       height = input.par$plot.height / 144,
       units = "in",
       dpi = 144,
-      device = input.par$plot_type
+      device = input.par$plot_type,
+      # Auto-sizing scales with .ri/.ci counts; for crosstabs with
+      # many populated cells (e.g. 24x112 wells) the computed
+      # dimensions can exceed ggsave's default 50-inch safety
+      # limit. Disable the cap.
+      limitsize = FALSE
     )
     
     return(tibble(plot_file = tmp, plot.width = input.par$plot.width, plot.height = input.par$plot.height))


### PR DESCRIPTION
## Summary
Plot dimensions are auto-computed from unique \`.ri\`/\`.ci\` counts:

\`\`\`
width  = 250 + 1.5 * cellSize * ncols
height = 150 + 1.25 * cellSize * nrows
\`\`\`

For crosstabs with many populated cells (e.g. the 24x112 wells in the customer's "tSNE & clusters by well" step) this easily exceeds ggsave's default 50-inch safety cap:

\`\`\`
Error in ggplot2::ggsave(): ! Dimensions exceed 50 inches
\`\`\`

The cap is purely a foot-gun guard against passing pixels-as-inches; we want the plot at the computed size.

## Test plan
- [ ] After 1.0.15 release, re-run "tSNE & clusters by well" step