### PR TITLE
Expose limit_size as a property (default false)

### DIFF
--- a/operator.json
+++ b/operator.json
@@ -173,6 +173,12 @@
       "description": "Whether to produce one plot per cell or not. Plots will be output as a zip file."
     },
     {
+      "kind": "BooleanProperty",
+      "name": "limit_size",
+      "defaultValue": false,
+      "description": "Enforce ggplot2's 50-inch ggsave safety cap. Default false: the operator already converts pixels to inches, so the cap blocks legitimately large many-cell crosstabs. Set true to re-enable the cap."
+    },
+    {
       "kind": "DoubleProperty",
       "name": "n_cells_max",
       "defaultValue": 50,

--- a/utils.R
+++ b/utils.R
@@ -625,8 +625,10 @@ generate_plot <-
       # Auto-sizing scales with .ri/.ci counts; for crosstabs with
       # many populated cells (e.g. 24x112 wells) the computed
       # dimensions can exceed ggsave's default 50-inch safety
-      # limit. Disable the cap.
-      limitsize = FALSE
+      # limit. Operator already converts pixels to inches so the
+      # cap is redundant — exposed as `limit_size` for users who
+      # want to keep ggplot2's default check.
+      limitsize = isTRUE(input.par$limit_size)
     )
     
     return(tibble(plot_file = tmp, plot.width = input.par$plot.width, plot.height = input.par$plot.height))


### PR DESCRIPTION
Replaces the hardcoded limitsize=FALSE from 1.0.15 with a BooleanProperty so users can opt back into ggplot2's 50-inch ggsave safety cap if desired. Default false because the operator already does pixels→inches conversion.