### PR TITLE
ci: resolve annotated tag SHA via GitHub API

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - name: Resolve annotated tag SHA
         id: tagsha
         # Tercen's installer derives the container tag from the GitHub
@@ -33,9 +31,20 @@ jobs:
         # annotated tags (not the commit SHA). Without this, the image
         # CI pushes (`:<commit-sha>`) and the image Tercen tries to pull
         # (`:<tag-sha>`) don't match.
+        #
+        # We must use the GitHub API rather than `git rev-parse`:
+        # actions/checkout@v4 stores the tag locally as a lightweight
+        # ref (pointing straight at the commit), so the annotated tag
+        # object isn't available in-tree. The /git/refs/tags endpoint
+        # returns .object.sha — the tag-object SHA when annotated, the
+        # commit SHA when lightweight — so the same code works for
+        # both tag styles.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          tag_sha=$(git rev-parse --short=7 "${GITHUB_REF#refs/tags/}")
-          echo "short=$tag_sha" >> "$GITHUB_OUTPUT"
+          tag="${GITHUB_REF#refs/tags/}"
+          sha=$(gh api "repos/${GITHUB_REPOSITORY}/git/refs/tags/${tag}" --jq '.object.sha')
+          echo "short=${sha:0:7}" >> "$GITHUB_OUTPUT"
       - name: Update container in operator JSON
         run: |
           jq --arg variable "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${GITHUB_REF##*/}" '.container = $variable' operator.json


### PR DESCRIPTION
## Summary
Follow-up to #19. The \`git rev-parse\` approach didn't actually work: \`actions/checkout@v4\` stores the tag locally as a lightweight ref (pointing straight at the commit), so for annotated tags rev-parse returned the **commit** SHA, not the tag-object SHA. Confirmed in the 1.0.15 build log:

\`\`\`
type=raw,value=8739576    ← commit SHA (wrong, also covered by type=sha)
\`\`\`

…while Tercen pulls \`:71e4c59\` (the tag object SHA from the zipball dir name).

Switch to \`gh api repos/.../git/refs/tags/<tag> --jq .object.sha\`. The API's \`.object.sha\` returns:
- annotated tag → tag-object SHA
- lightweight tag → commit SHA

…which is exactly what GitHub uses to name zipball directories, which is what Tercen's installer reads. Same code works for both tag styles.

Also drops \`fetch-depth: 0\` from the checkout — only needed for the rev-parse approach.

## Test plan
- [ ] Tag a new release (1.0.16+); confirm \`:<tag-sha>\` lands on ghcr without manual retag