### PR TITLE
memory_model: bump intercept and offset (2x / 1.7x)

### DIFF
--- a/memory_model.json
+++ b/memory_model.json
@@ -1,7 +1,7 @@
 {
   "kind": "OperatorEstimateModel",
-  "intercept": 0.0004,
-  "offset": 600.0,
+  "intercept": 0.0008,
+  "offset": 1000.0,
   "features": [
     {
       "kind": "Feature",


### PR DESCRIPTION
OOM at 6.43M rows — model predicted 3.39 GiB, actual peak before kill 3.53 GiB. Bump to ~6.6 GiB at this scale; ~41.5 GiB at 51M rows (within w2xlarge 256 GiB pool).